### PR TITLE
adding supported versions of python to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,10 @@ setup(
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: '
             'GNU General Public License v2 or later (GPLv2+)',
     ],


### PR DESCRIPTION
These versions currently all build on Travis CI.

I got a little confused when it appeared on [PyPI](https://pypi.org/project/cothread/) as if only Python 2.7 was supported... 